### PR TITLE
Rename replace node to avoid conflict with ComfyUI base component

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -2,20 +2,20 @@
 
 from .string_textbox_node import StringTextboxNode
 from .string_strip_node import StringStripNode
-from .string_replace_node import StringReplaceNode 
+from .string_multi_replace_node import StringMultiReplaceNode 
 from .string_preview_node import StringPreviewNode
 
 NODE_CLASS_MAPPINGS = {
     "StringTextbox": StringTextboxNode,
     "StringStrip": StringStripNode,
-    "StringReplace": StringReplaceNode,
+    "StringMultiReplace": StringMultiReplaceNode,
     "StringPreview": StringPreviewNode
 }
 
 NODE_DISPLAY_NAME_MAPPINGS = {
     "StringTextbox": "String Textbox",
     "StringStrip": "String Strip",
-    "StringReplace": "String Replace",
+    "StringMultiReplace": "String Multi Replace",
     "StringPreview": "String Preview"
 }
 

--- a/js/string_essentials.js
+++ b/js/string_essentials.js
@@ -13,9 +13,9 @@ app.registerExtension({
 });
 
 app.registerExtension({
-    name: "string.replace",
+    name: "string.multireplace",
     async beforeRegisterNodeDef(nodeType) {
-        if (nodeType.comfyClass === "StringReplace") {
+        if (nodeType.comfyClass === "StringMultiReplace") {
             nodeType.prototype.onNodeCreated = function() {
                 this.addInput("input_string", "STRING");
             };

--- a/string_multi_replace_node.py
+++ b/string_multi_replace_node.py
@@ -1,6 +1,6 @@
 import re
 
-class StringReplaceNode:
+class StringMultiReplaceNode:
     @classmethod
     def INPUT_TYPES(cls):
         return {


### PR DESCRIPTION
Just a simple rename to keep your replace from being clobbered by the ComfyUI base component. Lightly tested locally.